### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,19 @@ import os
 from datetime import date
 from setuptools import setup, find_packages
 
-# --- import your package ---
-import elementary_math as package
+# --- your package name ---
+packageName = 'elementary_math'
+
+pyPath = '%s/__init__.py'%packageName if os.path.isdir(packageName) else '%s.py'%packageName
+
+with open(pyPath) as f:
+    lines = f.readlines()
+code = ''.join(filter(lambda l: l.startswith('__') and '=' in l, lines))
+class Pack():
+    pass
+package = Pack()
+package.__name__ = packageName
+exec(code, package.__dict__)
 
 if __name__ == "__main__":
     # --- Automatically generate setup parameters ---


### PR DESCRIPTION
`import elementary_math as package` will be fail when package has install_requires and install from **PyPI mirror**(like https://pypi.tuna.tsinghua.edu.cn/simple)     
The Error like this one
```
        import skimage
ModuleNotFoundError: No module named 'skimage'
   ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-uwfirk47/boxx/
```
So I change the code to avoid import package